### PR TITLE
fix: add listener recovery for service restarts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,4 +45,5 @@ jobs:
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HUSKY: '0'
         run: npx semantic-release

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,7 +16,10 @@ android {
     abortOnError false
   }
   testOptions {
-    unitTests.returnDefaultValues = true
+    unitTests {
+      includeAndroidResources = true
+      returnDefaultValues = true
+    }
   }
 }
 
@@ -24,4 +27,5 @@ dependencies {
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.mockito:mockito-core:5.8.0'
   testImplementation 'org.mockito.kotlin:mockito-kotlin:5.2.1'
+  testImplementation 'org.robolectric:robolectric:4.11.1'
 }

--- a/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
+++ b/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
@@ -124,7 +124,7 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
         Log.d(TAG, "Accessibility service interrupted")
     }
 
-    override fun onServiceConnected() {
+    public override fun onServiceConnected() {
         super.onServiceConnected()
         isConnected = true
         Log.d(TAG, "Accessibility service connected, listeners=${eventListeners.size}")
@@ -138,13 +138,13 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
         Log.d(TAG, "Service connected broadcast sent")
     }
 
-    override fun onUnbind(intent: android.content.Intent?): Boolean {
+    public override fun onUnbind(intent: android.content.Intent?): Boolean {
         isConnected = false
         Log.d(TAG, "Accessibility service unbound (permission revoked or service disabled)")
         return super.onUnbind(intent)
     }
 
-    override fun onDestroy() {
+    public override fun onDestroy() {
         isConnected = false
         super.onDestroy()
         Log.d(TAG, "Accessibility service destroyed, listeners=${eventListeners.size}")

--- a/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
+++ b/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
@@ -1,5 +1,6 @@
 package expo.modules.accessibilityservice
 
+import android.content.Intent
 import android.view.accessibility.AccessibilityEvent
 import android.util.Log
 import java.util.Collections
@@ -13,6 +14,21 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
 
     companion object {
         private const val TAG = "AccessibilityService"
+
+        /**
+         * Broadcast action sent when the accessibility service (re)connects.
+         * Listeners can register a BroadcastReceiver for this action to re-register
+         * themselves after Android kills and restarts the service.
+         */
+        const val ACTION_SERVICE_CONNECTED = "expo.modules.accessibilityservice.SERVICE_CONNECTED"
+
+        /**
+         * Tracks whether the accessibility service is currently connected.
+         * Reset on process restart (static state is lost).
+         */
+        @Volatile
+        var isConnected: Boolean = false
+            private set
 
         // Thread-safe set of listeners (replaces single eventListener)
         private val eventListeners = Collections.synchronizedSet(mutableSetOf<EventListener>())
@@ -28,6 +44,16 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
             Log.d(TAG, "removeEventListener: removed=$removed, total=${eventListeners.size}")
             return removed
         }
+
+        /**
+         * Check if a specific listener is currently registered.
+         */
+        fun hasListener(listener: EventListener): Boolean = eventListeners.contains(listener)
+
+        /**
+         * Return the number of currently registered listeners.
+         */
+        fun getListenerCount(): Int = eventListeners.size
 
         @Deprecated(
             message = "Use addEventListener/removeEventListener for multiple listener support",
@@ -48,6 +74,9 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
         internal fun notifyListeners(packageName: String, className: String, timestamp: Long) {
             // Create snapshot to avoid ConcurrentModificationException during iteration
             val listeners = synchronized(eventListeners) { eventListeners.toList() }
+            if (listeners.isEmpty()) {
+                Log.w(TAG, "notifyListeners: no listeners registered, event dropped for $packageName")
+            }
             listeners.forEach { listener ->
                 try {
                     listener.onAppChanged(packageName, className, timestamp)
@@ -82,18 +111,27 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
 
     override fun onServiceConnected() {
         super.onServiceConnected()
-        Log.d(TAG, "Accessibility service connected")
+        isConnected = true
+        Log.d(TAG, "Accessibility service connected, listeners=${eventListeners.size}")
+
+        // Broadcast so that BlockingCallback (or any listener) can re-register
+        // after Android kills and restarts this service.
+        val intent = Intent(ACTION_SERVICE_CONNECTED).apply {
+            setPackage(packageName)
+        }
+        sendBroadcast(intent)
+        Log.d(TAG, "Service connected broadcast sent")
     }
 
     override fun onUnbind(intent: android.content.Intent?): Boolean {
+        isConnected = false
         Log.d(TAG, "Accessibility service unbound (permission revoked or service disabled)")
-        // This is called when the accessibility service is disabled
         return super.onUnbind(intent)
     }
 
     override fun onDestroy() {
+        isConnected = false
         super.onDestroy()
-        Log.d(TAG, "Accessibility service destroyed")
-        // Note: Listeners manage their own lifecycle via removeEventListener()
+        Log.d(TAG, "Accessibility service destroyed, listeners=${eventListeners.size}")
     }
 }

--- a/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
+++ b/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
@@ -90,7 +90,7 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
             // Create snapshot to avoid ConcurrentModificationException during iteration
             val listeners = synchronized(eventListeners) { eventListeners.toList() }
             if (listeners.isEmpty()) {
-                Log.d(TAG, "notifyListeners: no listeners registered, event dropped for $packageName")
+                Log.w(TAG, "notifyListeners: no listeners registered, event dropped for $packageName")
             }
             listeners.forEach { listener ->
                 try {

--- a/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
+++ b/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
@@ -55,6 +55,21 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
          */
         fun getListenerCount(): Int = eventListeners.size
 
+        /**
+         * Reset all state for testing purposes.
+         */
+        fun resetForTesting() {
+            eventListeners.clear()
+            isConnected = false
+        }
+
+        /**
+         * Set connection state for testing purposes.
+         */
+        fun setConnectedForTesting(connected: Boolean) {
+            isConnected = connected
+        }
+
         @Deprecated(
             message = "Use addEventListener/removeEventListener for multiple listener support",
             replaceWith = ReplaceWith("addEventListener(listener)")
@@ -75,7 +90,7 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
             // Create snapshot to avoid ConcurrentModificationException during iteration
             val listeners = synchronized(eventListeners) { eventListeners.toList() }
             if (listeners.isEmpty()) {
-                Log.w(TAG, "notifyListeners: no listeners registered, event dropped for $packageName")
+                Log.d(TAG, "notifyListeners: no listeners registered, event dropped for $packageName")
             }
             listeners.forEach { listener ->
                 try {
@@ -114,8 +129,8 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
         isConnected = true
         Log.d(TAG, "Accessibility service connected, listeners=${eventListeners.size}")
 
-        // Broadcast so that BlockingCallback (or any listener) can re-register
-        // after Android kills and restarts this service.
+        // Broadcast so that ExpoAccessibilityServiceModule (or any listener) can
+        // re-register after Android kills and restarts this service.
         val intent = Intent(ACTION_SERVICE_CONNECTED).apply {
             setPackage(packageName)
         }

--- a/android/src/main/java/expo/modules/accessibilityservice/ExpoAccessibilityServiceModule.kt
+++ b/android/src/main/java/expo/modules/accessibilityservice/ExpoAccessibilityServiceModule.kt
@@ -4,18 +4,22 @@ import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.Promise
 
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.IntentFilter
 import android.provider.Settings
 import android.text.TextUtils
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
+import android.os.Build
 import android.util.Log
 
 class ExpoAccessibilityServiceModule : Module(), AccessibilityService.EventListener {
 
   // Configurable service class name - can be set by the app
   private var serviceClassName: String? = null
+  private var serviceConnectedReceiver: BroadcastReceiver? = null
 
   companion object {
     private const val TAG = "ExpoAccessibilityModule"
@@ -31,11 +35,13 @@ class ExpoAccessibilityServiceModule : Module(), AccessibilityService.EventListe
     OnCreate {
       Log.d(TAG, "Module created, registering as event listener")
       AccessibilityService.addEventListener(this@ExpoAccessibilityServiceModule)
+      registerServiceConnectedReceiver()
     }
 
     // Unregister when module is destroyed to avoid memory leaks
     OnDestroy {
       Log.d(TAG, "Module destroyed, unregistering event listener")
+      unregisterServiceConnectedReceiver()
       AccessibilityService.removeEventListener(this@ExpoAccessibilityServiceModule)
     }
 
@@ -76,6 +82,39 @@ class ExpoAccessibilityServiceModule : Module(), AccessibilityService.EventListe
     } catch (e: Exception) {
       Log.e(TAG, "Error emitting accessibility event", e)
     }
+  }
+
+  private fun registerServiceConnectedReceiver() {
+    val receiver = object : BroadcastReceiver() {
+      override fun onReceive(ctx: Context?, intent: Intent?) {
+        if (intent?.action == AccessibilityService.ACTION_SERVICE_CONNECTED) {
+          Log.d(TAG, "Service connected broadcast received")
+          if (!AccessibilityService.hasListener(this@ExpoAccessibilityServiceModule)) {
+            AccessibilityService.addEventListener(this@ExpoAccessibilityServiceModule)
+            Log.d(TAG, "Re-registered as event listener after service restart")
+          }
+        }
+      }
+    }
+    val filter = IntentFilter(AccessibilityService.ACTION_SERVICE_CONNECTED)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      context.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
+    } else {
+      context.registerReceiver(receiver, filter)
+    }
+    serviceConnectedReceiver = receiver
+    Log.d(TAG, "Registered service connected receiver")
+  }
+
+  private fun unregisterServiceConnectedReceiver() {
+    serviceConnectedReceiver?.let {
+      try {
+        context.unregisterReceiver(it)
+      } catch (e: Exception) {
+        Log.w(TAG, "Failed to unregister service connected receiver: ${e.message}")
+      }
+    }
+    serviceConnectedReceiver = null
   }
 
   private val context

--- a/android/src/test/java/expo/modules/accessibilityservice/AccessibilityServiceLifecycleTest.kt
+++ b/android/src/test/java/expo/modules/accessibilityservice/AccessibilityServiceLifecycleTest.kt
@@ -1,0 +1,135 @@
+package expo.modules.accessibilityservice
+
+import android.content.Intent
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Lifecycle tests for AccessibilityService using Robolectric.
+ * Tests onServiceConnected broadcast, isConnected state transitions,
+ * and cleanup on unbind/destroy.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], manifest = Config.NONE)
+class AccessibilityServiceLifecycleTest {
+
+    @Before
+    fun setUp() {
+        AccessibilityService.resetForTesting()
+    }
+
+    @After
+    fun tearDown() {
+        AccessibilityService.resetForTesting()
+    }
+
+    @Test
+    fun `onServiceConnected sets isConnected to true`() {
+        val service = Robolectric.buildService(AccessibilityService::class.java)
+            .create()
+            .get()
+
+        assertFalse("isConnected should be false before onServiceConnected",
+            AccessibilityService.isConnected)
+
+        service.onServiceConnected()
+
+        assertTrue("isConnected should be true after onServiceConnected",
+            AccessibilityService.isConnected)
+    }
+
+    @Test
+    fun `onServiceConnected sends ACTION_SERVICE_CONNECTED broadcast`() {
+        val service = Robolectric.buildService(AccessibilityService::class.java)
+            .create()
+            .get()
+
+        service.onServiceConnected()
+
+        val shadowApp = shadowOf(RuntimeEnvironment.getApplication())
+        val broadcastIntents = shadowApp.broadcastIntents
+
+        assertTrue(
+            "ACTION_SERVICE_CONNECTED broadcast should be sent",
+            broadcastIntents.any { it.action == AccessibilityService.ACTION_SERVICE_CONNECTED }
+        )
+    }
+
+    @Test
+    fun `onServiceConnected broadcast is scoped to app package`() {
+        val service = Robolectric.buildService(AccessibilityService::class.java)
+            .create()
+            .get()
+
+        service.onServiceConnected()
+
+        val shadowApp = shadowOf(RuntimeEnvironment.getApplication())
+        val broadcastIntent = shadowApp.broadcastIntents
+            .first { it.action == AccessibilityService.ACTION_SERVICE_CONNECTED }
+
+        assertEquals(
+            "Broadcast should be scoped to app package",
+            service.packageName,
+            broadcastIntent.`package`
+        )
+    }
+
+    @Test
+    fun `onUnbind sets isConnected to false`() {
+        val service = Robolectric.buildService(AccessibilityService::class.java)
+            .create()
+            .get()
+
+        service.onServiceConnected()
+        assertTrue(AccessibilityService.isConnected)
+
+        service.onUnbind(Intent())
+
+        assertFalse("isConnected should be false after onUnbind",
+            AccessibilityService.isConnected)
+    }
+
+    @Test
+    fun `onDestroy sets isConnected to false`() {
+        val service = Robolectric.buildService(AccessibilityService::class.java)
+            .create()
+            .get()
+
+        service.onServiceConnected()
+        assertTrue(AccessibilityService.isConnected)
+
+        service.onDestroy()
+
+        assertFalse("isConnected should be false after onDestroy",
+            AccessibilityService.isConnected)
+    }
+
+    @Test
+    fun `onServiceConnected preserves existing listeners`() {
+        val listener = object : AccessibilityService.EventListener {
+            override fun onAppChanged(packageName: String, className: String, timestamp: Long) {}
+        }
+        AccessibilityService.addEventListener(listener)
+
+        val service = Robolectric.buildService(AccessibilityService::class.java)
+            .create()
+            .get()
+
+        service.onServiceConnected()
+
+        assertTrue("Existing listener should still be registered",
+            AccessibilityService.hasListener(listener))
+        assertEquals("Listener count should be preserved",
+            1, AccessibilityService.getListenerCount())
+    }
+}

--- a/android/src/test/java/expo/modules/accessibilityservice/AccessibilityServiceLifecycleTest.kt
+++ b/android/src/test/java/expo/modules/accessibilityservice/AccessibilityServiceLifecycleTest.kt
@@ -1,6 +1,9 @@
 package expo.modules.accessibilityservice
 
+import android.content.BroadcastReceiver
+import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -131,5 +134,98 @@ class AccessibilityServiceLifecycleTest {
             AccessibilityService.hasListener(listener))
         assertEquals("Listener count should be preserved",
             1, AccessibilityService.getListenerCount())
+    }
+
+    /**
+     * Tests the broadcast-triggered re-registration pattern used by
+     * ExpoAccessibilityServiceModule and BlockingCallback.
+     *
+     * ExpoAccessibilityServiceModule cannot be unit-tested directly because it
+     * depends on the Expo module framework (Module, ModuleDefinition, appContext).
+     * This test validates the same pattern: a BroadcastReceiver that listens for
+     * ACTION_SERVICE_CONNECTED and re-registers a dropped listener.
+     */
+    @Test
+    fun `broadcast receiver re-registers dropped listener on ACTION_SERVICE_CONNECTED`() {
+        val listener = object : AccessibilityService.EventListener {
+            override fun onAppChanged(packageName: String, className: String, timestamp: Long) {}
+        }
+
+        // Register listener, then simulate it being dropped by Android
+        AccessibilityService.addEventListener(listener)
+        AccessibilityService.removeEventListener(listener)
+        assertFalse("Listener should be dropped",
+            AccessibilityService.hasListener(listener))
+
+        // Register a BroadcastReceiver that re-registers the listener (same pattern as the module)
+        val context = RuntimeEnvironment.getApplication()
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(ctx: Context?, intent: Intent?) {
+                if (intent?.action == AccessibilityService.ACTION_SERVICE_CONNECTED) {
+                    if (!AccessibilityService.hasListener(listener)) {
+                        AccessibilityService.addEventListener(listener)
+                    }
+                }
+            }
+        }
+        context.registerReceiver(
+            receiver, IntentFilter(AccessibilityService.ACTION_SERVICE_CONNECTED)
+        )
+
+        // Simulate service restart — onServiceConnected sends the broadcast
+        val service = Robolectric.buildService(AccessibilityService::class.java)
+            .create()
+            .get()
+        service.onServiceConnected()
+
+        // Process the broadcast
+        shadowOf(RuntimeEnvironment.getApplication()).run {
+            val broadcastIntent = broadcastIntents
+                .first { it.action == AccessibilityService.ACTION_SERVICE_CONNECTED }
+            receiver.onReceive(context, broadcastIntent)
+        }
+
+        assertTrue("Listener should be re-registered after broadcast",
+            AccessibilityService.hasListener(listener))
+
+        context.unregisterReceiver(receiver)
+    }
+
+    @Test
+    fun `broadcast receiver does not duplicate listener if already registered`() {
+        val listener = object : AccessibilityService.EventListener {
+            override fun onAppChanged(packageName: String, className: String, timestamp: Long) {}
+        }
+
+        // Listener is already registered
+        AccessibilityService.addEventListener(listener)
+
+        val context = RuntimeEnvironment.getApplication()
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(ctx: Context?, intent: Intent?) {
+                if (!AccessibilityService.hasListener(listener)) {
+                    AccessibilityService.addEventListener(listener)
+                }
+            }
+        }
+        context.registerReceiver(
+            receiver, IntentFilter(AccessibilityService.ACTION_SERVICE_CONNECTED)
+        )
+
+        val service = Robolectric.buildService(AccessibilityService::class.java)
+            .create()
+            .get()
+        service.onServiceConnected()
+
+        shadowOf(RuntimeEnvironment.getApplication()).run {
+            val broadcastIntent = broadcastIntents
+                .first { it.action == AccessibilityService.ACTION_SERVICE_CONNECTED }
+            receiver.onReceive(context, broadcastIntent)
+        }
+
+        assertEquals("Should still have exactly 1 listener (no duplicate)",
+            1, AccessibilityService.getListenerCount())
+
+        context.unregisterReceiver(receiver)
     }
 }

--- a/android/src/test/java/expo/modules/accessibilityservice/AccessibilityServiceTest.kt
+++ b/android/src/test/java/expo/modules/accessibilityservice/AccessibilityServiceTest.kt
@@ -169,6 +169,17 @@ class AccessibilityServiceTest {
     }
 
     @Test
+    fun `setConnectedForTesting sets isConnected`() {
+        assertFalse("isConnected should be false initially", AccessibilityService.isConnected)
+
+        AccessibilityService.setConnectedForTesting(true)
+        assertTrue("isConnected should be true after setConnectedForTesting(true)", AccessibilityService.isConnected)
+
+        AccessibilityService.setConnectedForTesting(false)
+        assertFalse("isConnected should be false after setConnectedForTesting(false)", AccessibilityService.isConnected)
+    }
+
+    @Test
     fun `exception in one listener does not affect others`() {
         // Create a listener that throws an exception
         val throwingListener = object : AccessibilityService.EventListener {

--- a/android/src/test/java/expo/modules/accessibilityservice/AccessibilityServiceTest.kt
+++ b/android/src/test/java/expo/modules/accessibilityservice/AccessibilityServiceTest.kt
@@ -17,8 +17,7 @@ class AccessibilityServiceTest {
     @Before
     fun setUp() {
         // Clear any existing listeners before each test
-        @Suppress("DEPRECATION")
-        AccessibilityService.setEventListener(null)
+        AccessibilityService.resetForTesting()
 
         listener1 = mock()
         listener2 = mock()
@@ -28,8 +27,7 @@ class AccessibilityServiceTest {
     @After
     fun tearDown() {
         // Clean up after each test
-        @Suppress("DEPRECATION")
-        AccessibilityService.setEventListener(null)
+        AccessibilityService.resetForTesting()
     }
 
     @Test
@@ -156,6 +154,18 @@ class AccessibilityServiceTest {
     @Test
     fun `isConnected is false by default`() {
         assertFalse("isConnected should be false by default", AccessibilityService.isConnected)
+    }
+
+    @Test
+    fun `resetForTesting clears listeners and resets isConnected`() {
+        AccessibilityService.addEventListener(listener1)
+        AccessibilityService.addEventListener(listener2)
+        assertEquals("should have 2 listeners", 2, AccessibilityService.getListenerCount())
+
+        AccessibilityService.resetForTesting()
+
+        assertEquals("listeners should be cleared", 0, AccessibilityService.getListenerCount())
+        assertFalse("isConnected should be false after reset", AccessibilityService.isConnected)
     }
 
     @Test

--- a/android/src/test/java/expo/modules/accessibilityservice/AccessibilityServiceTest.kt
+++ b/android/src/test/java/expo/modules/accessibilityservice/AccessibilityServiceTest.kt
@@ -124,6 +124,41 @@ class AccessibilityServiceTest {
     }
 
     @Test
+    fun `hasListener returns true for registered listener`() {
+        AccessibilityService.addEventListener(listener1)
+
+        assertTrue("hasListener should return true for registered listener", AccessibilityService.hasListener(listener1))
+        assertFalse("hasListener should return false for unregistered listener", AccessibilityService.hasListener(listener2))
+    }
+
+    @Test
+    fun `hasListener returns false after removal`() {
+        AccessibilityService.addEventListener(listener1)
+        AccessibilityService.removeEventListener(listener1)
+
+        assertFalse("hasListener should return false after removal", AccessibilityService.hasListener(listener1))
+    }
+
+    @Test
+    fun `getListenerCount tracks registered listeners`() {
+        assertEquals("getListenerCount should be 0 initially", 0, AccessibilityService.getListenerCount())
+
+        AccessibilityService.addEventListener(listener1)
+        assertEquals("getListenerCount should be 1 after adding one", 1, AccessibilityService.getListenerCount())
+
+        AccessibilityService.addEventListener(listener2)
+        assertEquals("getListenerCount should be 2 after adding two", 2, AccessibilityService.getListenerCount())
+
+        AccessibilityService.removeEventListener(listener1)
+        assertEquals("getListenerCount should be 1 after removing one", 1, AccessibilityService.getListenerCount())
+    }
+
+    @Test
+    fun `isConnected is false by default`() {
+        assertFalse("isConnected should be false by default", AccessibilityService.isConnected)
+    }
+
+    @Test
     fun `exception in one listener does not affect others`() {
         // Create a listener that throws an exception
         val throwingListener = object : AccessibilityService.EventListener {


### PR DESCRIPTION
## Summary
- Adds listener recovery infrastructure for accessibility service restarts (amehmeto/TiedSiren51#419)
- `ACTION_SERVICE_CONNECTED` broadcast sent from `onServiceConnected()` so consumers can detect restarts
- `isConnected` volatile flag tracks whether the service is currently alive
- `hasListener()` / `getListenerCount()` utilities to check listener state before re-registering
- `BroadcastReceiver` in `ExpoAccessibilityServiceModule` re-registers the module as a listener on service reconnect
- Warning log when `notifyListeners` fires with zero listeners

**Note:** This PR provides the foundation APIs that [tied-siren-blocking-overlay PR #23](https://github.com/amehmeto/tied-siren-blocking-overlay/pull/23) depends on. Must be merged first.

## Test plan
- [x] Unit tests for `hasListener`, `getListenerCount`, `isConnected`, `resetForTesting`
- [x] Robolectric lifecycle tests for `onServiceConnected` (sets `isConnected`, sends broadcast, scopes to package)
- [x] Robolectric tests for `onUnbind` and `onDestroy` (reset `isConnected`)
- [ ] Verify listener re-registers after service restart on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)