### PR TITLE
ci: fix semantic-release branch protection failure

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,18 +3,10 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
     [
       "@semantic-release/npm",
       {
         "npmPublish": false
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
## Summary
- Remove `@semantic-release/git` and `@semantic-release/changelog` plugins that fail with `GH006: Protected branch update failed` when pushing to main
- GitHub releases and tags still created via `@semantic-release/github` API

## Test plan
- [ ] Merge PR and verify the Release workflow passes on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)