### PR TITLE
ci: fix semantic-release success step failure

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,6 +9,12 @@
         "npmPublish": false
       }
     ],
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "failComment": false
+      }
+    ]
   ]
 }


### PR DESCRIPTION
## Summary
- Disable `successComment` and `failComment` in `@semantic-release/github` plugin config
- Root cause: commit f10ba54 references `Closes #171` (external tracker issue) which doesn't exist in this GitHub repo
- The plugin's `success` step tries to comment on #171 via GraphQL, gets `NOT_FOUND`, and crashes the entire release workflow
- Tags and GitHub releases are still created correctly — only the post-release comment step was failing

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, the Release workflow on `main` completes successfully (no `NOT_FOUND` error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)