### PR TITLE
ci: remove @semantic-release/git to fix branch protection failure

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,18 +3,10 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
     [
       "@semantic-release/npm",
       {
         "npmPublish": false
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
GITHUB_TOKEN cannot push commits to protected main branch (GH006). Remove @semantic-release/git and @semantic-release/changelog plugins — GitHub releases and tags are still created via @semantic-release/github API.