### PR TITLE
feat(android): Sentry breadcrumb on accessibility event dispatch

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,8 @@ android {
 }
 
 dependencies {
+  compileOnly 'io.sentry:sentry-android:7.3.0'
+
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.mockito:mockito-core:5.8.0'
   testImplementation 'org.mockito.kotlin:mockito-kotlin:5.2.1'

--- a/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
+++ b/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
@@ -5,6 +5,8 @@ import android.content.Intent
 import android.provider.Settings
 import android.view.accessibility.AccessibilityEvent
 import android.util.Log
+import io.sentry.Breadcrumb
+import io.sentry.Sentry
 import java.util.Collections
 
 class AccessibilityService : android.accessibilityservice.AccessibilityService() {
@@ -200,6 +202,20 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
                 val timestamp = System.currentTimeMillis()
 
                 Log.d(TAG, "App changed: package=$packageName, class=$className")
+
+                try {
+                    val breadcrumb = Breadcrumb().apply {
+                        category = "accessibility"
+                        message = "event received"
+                        setData("eventType", event.eventType)
+                        setData("packageName", packageName)
+                        setData("receivedAtMillis", timestamp)
+                        setData("listenerCount", eventListeners.size)
+                    }
+                    Sentry.addBreadcrumb(breadcrumb)
+                } catch (_: Throwable) {
+                    // Sentry may not be initialized (standalone module, tests)
+                }
 
                 notifyListeners(packageName, className, timestamp)
             }

--- a/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
+++ b/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
@@ -204,17 +204,20 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
                 Log.d(TAG, "App changed: package=$packageName, class=$className")
 
                 try {
-                    val breadcrumb = Breadcrumb().apply {
-                        category = "accessibility"
-                        message = "event received"
-                        setData("eventType", event.eventType)
-                        setData("packageName", packageName)
-                        setData("receivedAtMillis", timestamp)
-                        setData("listenerCount", eventListeners.size)
+                    if (Sentry.isEnabled()) {
+                        Sentry.addBreadcrumb(
+                            Breadcrumb().apply {
+                                category = "accessibility"
+                                message = "event received"
+                                setData("eventType", event.eventType)
+                                setData("packageName", packageName)
+                                setData("receivedAtMillis", timestamp)
+                                setData("listenerCount", eventListeners.size)
+                            }
+                        )
                     }
-                    Sentry.addBreadcrumb(breadcrumb)
                 } catch (_: Throwable) {
-                    // Sentry may not be initialized (standalone module, tests)
+                    // Sentry class may be absent at runtime (compileOnly, host app didn't bundle it)
                 }
 
                 notifyListeners(packageName, className, timestamp)


### PR DESCRIPTION
## Summary

Instrumentation-only change. Adds **one Sentry breadcrumb** in `AccessibilityService.onAccessibilityEvent` to measure the boundary between OS-level `AccessibilityEvent` delivery and our listener dispatch.

This is the missing piece between EFS scope (alarm scheduling) and tsbo scope (`onAppChanged` handling) for diagnosing the ~7-10 min blocking-overlay lag.

## Breadcrumb

**Location**: `android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt`, just before `notifyListeners(...)` inside the `TYPE_WINDOW_STATE_CHANGED` branch of `onAccessibilityEvent`.

**Shape**:
- `category`: `accessibility`
- `message`: `event received`
- `data`:
  - `eventType` (Int)
  - `packageName` (String)
  - `receivedAtMillis` (Long — same `timestamp` passed to listeners)
  - `listenerCount` (Int — `eventListeners.size` at dispatch time)

`listenerCount == 0` means the event was dropped (no one registered) — useful to distinguish a registration bug from a downstream lag.

## Sentry SDK

- Added `compileOnly 'io.sentry:sentry-android:7.3.0'` in `android/build.gradle`. Mirrors the pattern used by `tied-siren-blocking-overlay`: Sentry is provided at runtime by the host app (`@sentry/react-native`).
- This module does **not** init Sentry — host app is responsible.
- The `addBreadcrumb` call is wrapped in `try/catch` so the module remains safe when loaded standalone (example app, tests).

## Constraints honored

- Generic module — no TiedSiren-specific terms ("blocking", "siren") in message or data.
- No business logic changes. No refactor of `onAccessibilityEvent`, `notifyListeners`, or the event-type filter.
- Existing 72 JS tests pass; no new tests added (instrumentation-only).
- ktlint clean.

## Test plan

- [x] `npm test` — 72/72 passing
- [x] `npm run lint` — clean
- [ ] Android build (`./gradlew assembleDebug`) — not run locally (no Android SDK on this machine); CI will validate

Refs amehmeto/TiedSiren#443

🤖 Generated with [Claude Code](https://claude.com/claude-code)