### PR TITLE
feat(a11y): bind-truth detection + emit hardening (overlay race)

### DIFF
--- a/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
+++ b/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
@@ -106,6 +106,13 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
         }
 
         /**
+         * Pure matcher: is [expectedId] present in the system's bound-services id list?
+         * Extracted so the id-matching contract is unit-testable without the framework.
+         */
+        internal fun matchesBoundService(boundServiceIds: List<String>, expectedId: String): Boolean =
+            expectedId in boundServiceIds
+
+        /**
          * Reset all state for testing purposes.
          */
         fun resetForTesting() {

--- a/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
+++ b/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
@@ -6,6 +6,8 @@ import android.provider.Settings
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityManager
 import android.accessibilityservice.AccessibilityServiceInfo
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import io.sentry.Breadcrumb
 import io.sentry.Sentry
@@ -166,42 +168,62 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
 
         fun getEventListener(): EventListener? = eventListeners.firstOrNull()
 
-        /**
-         * Emit the current foreground app as a synthetic accessibility event.
-         * Uses rootInActiveWindow to determine what app is currently on screen.
-         * This is useful when the service starts while an app is already in the foreground
-         * (no TYPE_WINDOW_STATE_CHANGED event fires for already-visible apps).
-         */
         fun emitCurrentForegroundApp() {
+            emitCurrentForegroundApp(attempt = 0)
+        }
+
+        private const val EMIT_MAX_ATTEMPTS = 3
+        private const val EMIT_RETRY_DELAY_MS = 150L
+
+        private fun emitCurrentForegroundApp(attempt: Int) {
             val service = instance
             if (service == null) {
                 Log.w(TAG, "emitCurrentForegroundApp: service instance not available")
                 return
             }
 
-            try {
-                val rootNode = service.rootInActiveWindow
-                if (rootNode == null) {
-                    Log.w(TAG, "emitCurrentForegroundApp: rootInActiveWindow is null")
-                    return
+            val resolved = resolveForegroundPackage(service)
+            if (resolved == null) {
+                if (attempt + 1 < EMIT_MAX_ATTEMPTS) {
+                    Log.w(TAG, "emitCurrentForegroundApp: no package (attempt ${attempt + 1}), retrying")
+                    Handler(Looper.getMainLooper()).postDelayed(
+                        { emitCurrentForegroundApp(attempt + 1) },
+                        EMIT_RETRY_DELAY_MS
+                    )
+                } else {
+                    Log.w(TAG, "emitCurrentForegroundApp: no package after $EMIT_MAX_ATTEMPTS attempts")
                 }
-
-                val packageName = rootNode.packageName?.toString()
-                val className = rootNode.className?.toString() ?: "android.view.View"
-                // recycle() is deprecated on API 34+ (no-op); safe to call on older APIs
-                rootNode.recycle()
-
-                if (packageName.isNullOrEmpty()) {
-                    Log.w(TAG, "emitCurrentForegroundApp: no package name from root node")
-                    return
-                }
-
-                val timestamp = System.currentTimeMillis()
-                Log.d(TAG, "emitCurrentForegroundApp: emitting $packageName")
-                notifyListeners(packageName, className, timestamp)
-            } catch (e: Exception) {
-                Log.e(TAG, "emitCurrentForegroundApp failed: ${e.message}", e)
+                return
             }
+
+            val timestamp = System.currentTimeMillis()
+            Log.d(TAG, "emitCurrentForegroundApp: emitting ${resolved.first}")
+            notifyListeners(resolved.first, resolved.second, timestamp)
+        }
+
+        /** Returns (packageName, className) of the active window, or null. */
+        private fun resolveForegroundPackage(service: AccessibilityService): Pair<String, String>? {
+            try {
+                val root = service.rootInActiveWindow
+                if (root != null) {
+                    val pkg = root.packageName?.toString()
+                    val cls = root.className?.toString() ?: "android.view.View"
+                    root.recycle()
+                    if (!pkg.isNullOrEmpty()) return pkg to cls
+                }
+                // Fallback: scan interactive windows for the active application window's root.
+                for (window in service.windows) {
+                    if (!window.isActive) continue
+                    val wRoot = window.root ?: continue
+                    val pkg = wRoot.packageName?.toString()
+                    val cls = wRoot.className?.toString() ?: "android.view.View"
+                    wRoot.recycle()
+                    if (!pkg.isNullOrEmpty()) return pkg to cls
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "resolveForegroundPackage failed: ${e.message}", e)
+            }
+            return null
         }
 
         /**

--- a/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
+++ b/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.Intent
 import android.provider.Settings
 import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityManager
+import android.accessibilityservice.AccessibilityServiceInfo
 import android.util.Log
 import io.sentry.Breadcrumb
 import io.sentry.Sentry
@@ -111,6 +113,32 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
          */
         internal fun matchesBoundService(boundServiceIds: List<String>, expectedId: String): Boolean =
             expectedId in boundServiceIds
+
+        /**
+         * Whether this accessibility service is actually BOUND and running — not merely
+         * listed in Settings.Secure. The in-process signal ([isConnected] + [instance]) is
+         * strongest (the service runs in this app's process); the system bound-services
+         * view ([AccessibilityManager.getEnabledAccessibilityServiceList]) corroborates it
+         * and is correct even after a process restart that cleared the in-process statics.
+         *
+         * Combined via OR: bound if EITHER says so. Distinguishes "enabled in settings but
+         * not bound" (Restricted Settings / ECM on a sideloaded install, or an unbind after
+         * process death) from genuinely running.
+         */
+        fun isServiceRunning(context: Context): Boolean {
+            if (isConnected && instance != null) return true
+            return try {
+                val expectedId = "${context.packageName}/${AccessibilityService::class.java.canonicalName}"
+                val manager = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+                val boundIds = manager
+                    .getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_ALL_MASK)
+                    .map { it.id }
+                matchesBoundService(boundIds, expectedId)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to check if accessibility service is running: ${e.message}", e)
+                false
+            }
+        }
 
         /**
          * Reset all state for testing purposes.

--- a/android/src/main/java/expo/modules/accessibilityservice/ExpoAccessibilityServiceModule.kt
+++ b/android/src/main/java/expo/modules/accessibilityservice/ExpoAccessibilityServiceModule.kt
@@ -57,6 +57,10 @@ class ExpoAccessibilityServiceModule : Module(), AccessibilityService.EventListe
       openAccessibilitySettings(promise)
     }
 
+    AsyncFunction("openAppDetailsSettings") { promise: Promise ->
+      openAppDetailsSettings(promise)
+    }
+
     AsyncFunction("setServiceClassName") { className: String, promise: Promise ->
       serviceClassName = className
       promise.resolve()
@@ -189,6 +193,21 @@ class ExpoAccessibilityServiceModule : Module(), AccessibilityService.EventListe
       promise.resolve()
     } catch (e: Exception) {
       promise.reject("ERROR", "Could not open accessibility settings: ${e.message}", e)
+    }
+  }
+
+  private fun openAppDetailsSettings(promise: Promise) {
+    try {
+      val intent = Intent(
+        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+        android.net.Uri.fromParts("package", context.packageName, null)
+      ).apply {
+        flags = Intent.FLAG_ACTIVITY_NEW_TASK
+      }
+      context.startActivity(intent)
+      promise.resolve()
+    } catch (e: Exception) {
+      promise.reject("ERROR", "Could not open app details settings: ${e.message}", e)
     }
   }
 }

--- a/android/src/main/java/expo/modules/accessibilityservice/ExpoAccessibilityServiceModule.kt
+++ b/android/src/main/java/expo/modules/accessibilityservice/ExpoAccessibilityServiceModule.kt
@@ -49,6 +49,10 @@ class ExpoAccessibilityServiceModule : Module(), AccessibilityService.EventListe
       promise.resolve(isEnabled)
     }
 
+    AsyncFunction("isServiceRunning") { promise: Promise ->
+      promise.resolve(AccessibilityService.isServiceRunning(context))
+    }
+
     AsyncFunction("askPermission") { promise: Promise ->
       openAccessibilitySettings(promise)
     }

--- a/android/src/main/res/xml/accessibility_service_config.xml
+++ b/android/src/main/res/xml/accessibility_service_config.xml
@@ -2,6 +2,7 @@
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
       android:accessibilityEventTypes="typeAllMask"
       android:accessibilityFeedbackType="feedbackAllMask"
+      android:accessibilityFlags="flagRetrieveInteractiveWindows"
       android:notificationTimeout="100"
-      android:canRetrieveWindowContent="true" 
+      android:canRetrieveWindowContent="true"
       />

--- a/android/src/test/java/expo/modules/accessibilityservice/IsServiceRunningMatcherTest.kt
+++ b/android/src/test/java/expo/modules/accessibilityservice/IsServiceRunningMatcherTest.kt
@@ -1,0 +1,27 @@
+package expo.modules.accessibilityservice
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IsServiceRunningMatcherTest {
+
+    private val expected = "com.tiedsiren.tiedsiren/expo.modules.accessibilityservice.AccessibilityService"
+
+    @Test
+    fun `returns true when expected id is in the bound list`() {
+        val bound = listOf("other.app/other.Service", expected)
+        assertTrue(AccessibilityService.matchesBoundService(bound, expected))
+    }
+
+    @Test
+    fun `returns false when expected id is absent`() {
+        val bound = listOf("other.app/other.Service")
+        assertFalse(AccessibilityService.matchesBoundService(bound, expected))
+    }
+
+    @Test
+    fun `returns false for an empty bound list`() {
+        assertFalse(AccessibilityService.matchesBoundService(emptyList(), expected))
+    }
+}

--- a/src/ExpoAccessibilityServiceModule.ts
+++ b/src/ExpoAccessibilityServiceModule.ts
@@ -5,6 +5,7 @@ import { ExpoAccessibilityServiceModuleEvents } from './ExpoAccessibilityService
 declare class ExpoAccessibilityServiceModule extends NativeModule<ExpoAccessibilityServiceModuleEvents> {
   isEnabled: () => Promise<boolean>
   isServiceRunning: () => Promise<boolean>
+  openAppDetailsSettings: () => Promise<void>
   askPermission: () => Promise<void>
   setServiceClassName: (className: string) => Promise<void>
   getDetectedServices: () => Promise<string[]>

--- a/src/ExpoAccessibilityServiceModule.ts
+++ b/src/ExpoAccessibilityServiceModule.ts
@@ -4,6 +4,7 @@ import { ExpoAccessibilityServiceModuleEvents } from './ExpoAccessibilityService
 
 declare class ExpoAccessibilityServiceModule extends NativeModule<ExpoAccessibilityServiceModuleEvents> {
   isEnabled: () => Promise<boolean>
+  isServiceRunning: () => Promise<boolean>
   askPermission: () => Promise<void>
   setServiceClassName: (className: string) => Promise<void>
   getDetectedServices: () => Promise<string[]>

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,10 @@ export function isEnabled(): Promise<boolean> {
   return ExpoAccessibilityServiceModule.isEnabled()
 }
 
+export function isServiceRunning(): Promise<boolean> {
+  return ExpoAccessibilityServiceModule.isServiceRunning()
+}
+
 export function askPermission(): Promise<void> {
   return ExpoAccessibilityServiceModule.askPermission()
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,10 @@ export function isServiceRunning(): Promise<boolean> {
   return ExpoAccessibilityServiceModule.isServiceRunning()
 }
 
+export function openAppDetailsSettings(): Promise<void> {
+  return ExpoAccessibilityServiceModule.openAppDetailsSettings()
+}
+
 export function askPermission(): Promise<void> {
   return ExpoAccessibilityServiceModule.askPermission()
 }


### PR DESCRIPTION
Part of the cross-repo fix for the start-now blocking-overlay race — see amehmeto/TiedSiren#621.

## What
- Pure, unit-tested bound-service id matcher.
- `isServiceRunning()` — reports the *true* bound state of the AccessibilityService (in-process `isConnected`/`instance` **or** the system `getEnabledAccessibilityServiceList`), not just `Settings.Secure`. Distinguishes "enabled in Settings but not actually bound" (sideloaded installs under Restricted Settings / ECM) from genuinely running.
- `openAppDetailsSettings()` — opens App Details so the user can clear Restricted Settings and re-toggle.
- Hardened `emitCurrentForegroundApp()` — retry (3×150ms) + `getWindows()` fallback + `flagRetrieveInteractiveWindows`, so the foreground read doesn't come back empty in the split second right after the service starts.

## Why
Gives the host a bind-truth signal (for a remediation card) and makes the immediate foreground emit robust at session start. Full root cause in the linked issue.

Confirmed fixed on the reporter's Pixel 9a (Android 16).
