### PR TITLE
feat: emit browser URL-bar changes as a typed detection event

### DIFF
--- a/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
+++ b/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
@@ -40,12 +40,39 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
          * resource id of their address-bar text field. Restricting work to these
          * packages keeps the hot path off every other app's content events.
          *
-         * Known V1 limitation: other browsers (Brave, Firefox, Opera, …) are absent
-         * and therefore not blocked.
+         * Grouped by engine: Chromium forks expose the omnibox as `<package>:id/url_bar`,
+         * the Opera family uses `url_field`, and Firefox/GeckoView (Mozilla Android
+         * Components) uses `mozac_browser_toolbar_url_view`. An unsupported browser (or a
+         * wrong id) simply isn't blocked rather than misbehaving.
          */
         val BROWSER_URL_BAR_VIEW_IDS: Map<String, String> = mapOf(
+            // Chromium-based: "<package>:id/url_bar"
             "com.android.chrome" to "com.android.chrome:id/url_bar",
-            "com.sec.android.app.sbrowser" to "com.sec.android.app.sbrowser:id/location_bar_edit_text"
+            "com.chrome.beta" to "com.chrome.beta:id/url_bar",
+            "com.chrome.dev" to "com.chrome.dev:id/url_bar",
+            "com.brave.browser" to "com.brave.browser:id/url_bar",
+            "com.brave.browser_beta" to "com.brave.browser_beta:id/url_bar",
+            "com.microsoft.emmx" to "com.microsoft.emmx:id/url_bar", // Edge
+            "com.vivaldi.browser" to "com.vivaldi.browser:id/url_bar",
+            "com.kiwibrowser.browser" to "com.kiwibrowser.browser:id/url_bar",
+            // Samsung Internet
+            "com.sec.android.app.sbrowser" to "com.sec.android.app.sbrowser:id/location_bar_edit_text",
+            // Opera family: "<package>:id/url_field"
+            "com.opera.browser" to "com.opera.browser:id/url_field",
+            "com.opera.browser.beta" to "com.opera.browser.beta:id/url_field",
+            "com.opera.mini.native" to "com.opera.mini.native:id/url_field",
+            "com.opera.gx" to "com.opera.gx:id/url_field",
+            // Firefox / GeckoView (Mozilla Android Components toolbar)
+            "org.mozilla.firefox" to "org.mozilla.firefox:id/mozac_browser_toolbar_url_view",
+            "org.mozilla.firefox_beta" to "org.mozilla.firefox_beta:id/mozac_browser_toolbar_url_view",
+            "org.mozilla.fenix" to "org.mozilla.fenix:id/mozac_browser_toolbar_url_view",
+            "org.mozilla.focus" to "org.mozilla.focus:id/mozac_browser_toolbar_url_view",
+            "org.mozilla.klar" to "org.mozilla.klar:id/mozac_browser_toolbar_url_view",
+            // DuckDuckGo
+            "com.duckduckgo.mobile.android" to "com.duckduckgo.mobile.android:id/omnibarTextInput",
+            // Best-effort (ids unverified on-device; wrong id ⇒ just not blocked there)
+            "com.UCMobile.intl" to "com.UCMobile.intl:id/address_bar",
+            "com.mi.globalbrowser" to "com.mi.globalbrowser:id/url",
         )
 
         /** Whether [packageName] is a browser we extract URL-bar text from. */

--- a/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
+++ b/android/src/main/java/expo/modules/accessibilityservice/AccessibilityService.kt
@@ -18,10 +18,56 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
     // Callback interface for event listeners
     interface EventListener {
         fun onAppChanged(packageName: String, className: String, timestamp: Long)
+
+        /**
+         * Called when the URL bar (omnibox) text of a supported browser changes.
+         *
+         * [rawText] is the unnormalized text shown in the address bar. Consumers are
+         * responsible for normalization (lowercase, strip scheme/www/path/query) and
+         * eTLD+1 resolution — this layer only surfaces the raw browser URL signal.
+         *
+         * Default no-op so existing listeners that only care about app changes do
+         * not need to implement it.
+         */
+        fun onUrlBarChanged(packageName: String, rawText: String, timestamp: Long) {}
     }
 
     companion object {
         private const val TAG = "AccessibilityService"
+
+        /**
+         * Browser packages whose URL bar we watch for website blocking, mapped to the
+         * resource id of their address-bar text field. Restricting work to these
+         * packages keeps the hot path off every other app's content events.
+         *
+         * Known V1 limitation: other browsers (Brave, Firefox, Opera, …) are absent
+         * and therefore not blocked.
+         */
+        val BROWSER_URL_BAR_VIEW_IDS: Map<String, String> = mapOf(
+            "com.android.chrome" to "com.android.chrome:id/url_bar",
+            "com.sec.android.app.sbrowser" to "com.sec.android.app.sbrowser:id/location_bar_edit_text"
+        )
+
+        /** Whether [packageName] is a browser we extract URL-bar text from. */
+        fun isSupportedBrowser(packageName: String?): Boolean =
+            packageName != null && BROWSER_URL_BAR_VIEW_IDS.containsKey(packageName)
+
+        /**
+         * Decide what URL-bar text (if any) to emit for a browser content/text event.
+         *
+         * Pure and string-only so it is unit-testable without a real
+         * AccessibilityNodeInfo. Returns the trimmed text to emit, or null when the
+         * event should be ignored: a non-browser package, a field that is not the
+         * browser's URL bar, or empty/blank text (new tab, hint placeholder).
+         */
+        fun resolveUrlBarText(packageName: String?, sourceViewId: String?, text: String?): String? {
+            if (!isSupportedBrowser(packageName)) return null
+            val expectedViewId = BROWSER_URL_BAR_VIEW_IDS[packageName] ?: return null
+            if (sourceViewId != expectedViewId) return null
+            val trimmed = text?.trim()
+            if (trimmed.isNullOrEmpty()) return null
+            return trimmed
+        }
 
         /**
          * Broadcast action sent when the accessibility service (re)connects.
@@ -245,40 +291,108 @@ class AccessibilityService : android.accessibilityservice.AccessibilityService()
                 }
             }
         }
+
+        /**
+         * Notify all registered listeners of a browser URL-bar change.
+         * Mirrors [notifyListeners]: snapshot to avoid ConcurrentModificationException,
+         * each listener guarded so one failure does not starve the others.
+         */
+        internal fun notifyUrlBarListeners(packageName: String, rawText: String, timestamp: Long) {
+            val listeners = synchronized(eventListeners) { eventListeners.toList() }
+            listeners.forEach { listener ->
+                try {
+                    listener.onUrlBarChanged(packageName, rawText, timestamp)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error notifying url-bar listener: ${e.message}", e)
+                }
+            }
+        }
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
         if (event == null) return
 
-        // Only handle window state changed events (foreground app changes)
-        if (event.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) {
-            val packageName = event.packageName?.toString()
-            val className = event.className?.toString()
+        when (event.eventType) {
+            // Foreground app changes (used by app blocking).
+            AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> handleWindowStateChanged(event)
 
-            if (!packageName.isNullOrEmpty() && !className.isNullOrEmpty()) {
-                val timestamp = System.currentTimeMillis()
+            // In-tab navigation does not fire a window-state change; it surfaces as a
+            // text/content change. Used by website blocking, filtered to browsers.
+            AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED,
+            AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED -> handleBrowserContentChanged(event)
+        }
+    }
 
-                Log.d(TAG, "App changed: package=$packageName, class=$className")
+    private fun handleWindowStateChanged(event: AccessibilityEvent) {
+        val packageName = event.packageName?.toString()
+        val className = event.className?.toString()
 
-                try {
-                    if (Sentry.isEnabled()) {
-                        Sentry.addBreadcrumb(
-                            Breadcrumb().apply {
-                                category = "accessibility"
-                                message = "event received"
-                                setData("eventType", event.eventType)
-                                setData("packageName", packageName)
-                                setData("receivedAtMillis", timestamp)
-                                setData("listenerCount", eventListeners.size)
-                            }
-                        )
-                    }
-                } catch (_: Throwable) {
-                    // Sentry class may be absent at runtime (compileOnly, host app didn't bundle it)
+        if (!packageName.isNullOrEmpty() && !className.isNullOrEmpty()) {
+            val timestamp = System.currentTimeMillis()
+
+            Log.d(TAG, "App changed: package=$packageName, class=$className")
+
+            try {
+                if (Sentry.isEnabled()) {
+                    Sentry.addBreadcrumb(
+                        Breadcrumb().apply {
+                            category = "accessibility"
+                            message = "event received"
+                            setData("eventType", event.eventType)
+                            setData("packageName", packageName)
+                            setData("receivedAtMillis", timestamp)
+                            setData("listenerCount", eventListeners.size)
+                        }
+                    )
                 }
-
-                notifyListeners(packageName, className, timestamp)
+            } catch (_: Throwable) {
+                // Sentry class may be absent at runtime (compileOnly, host app didn't bundle it)
             }
+
+            notifyListeners(packageName, className, timestamp)
+        }
+    }
+
+    private fun handleBrowserContentChanged(event: AccessibilityEvent) {
+        val packageName = event.packageName?.toString()
+        if (!isSupportedBrowser(packageName)) return
+
+        // Prefer the text already on the event when the changed node IS the URL bar,
+        // so we avoid a fresh node query on every content event. Fall back to a
+        // view-id lookup on the active window's root otherwise.
+        val source = event.source
+        val resolved = try {
+            val eventText = event.text?.joinToString("")?.takeIf { it.isNotEmpty() }
+            resolveUrlBarText(packageName, source?.viewIdResourceName, eventText)
+                ?: queryUrlBarFromRoot(packageName!!)
+        } finally {
+            // recycle() is deprecated/no-op on API 34+ but safe on older APIs
+            source?.recycle()
+        }
+
+        if (resolved != null) {
+            Log.d(TAG, "URL bar changed in $packageName")
+            notifyUrlBarListeners(packageName!!, resolved, System.currentTimeMillis())
+        }
+    }
+
+    /**
+     * Read the URL-bar text by querying the active window's root for the browser's
+     * known address-bar view id. Heavily guarded: any failure or missing node yields
+     * null rather than crashing the service.
+     */
+    private fun queryUrlBarFromRoot(packageName: String): String? {
+        return try {
+            val viewId = BROWSER_URL_BAR_VIEW_IDS[packageName] ?: return null
+            val root = rootInActiveWindow ?: return null
+            val nodes = root.findAccessibilityNodeInfosByViewId(viewId)
+            val text = nodes?.firstOrNull()?.text?.toString()?.trim()
+            nodes?.forEach { it.recycle() }
+            root.recycle()
+            if (text.isNullOrEmpty()) null else text
+        } catch (e: Exception) {
+            Log.e(TAG, "queryUrlBarFromRoot failed: ${e.message}", e)
+            null
         }
     }
 

--- a/android/src/test/java/expo/modules/accessibilityservice/UrlBarDetectionTest.kt
+++ b/android/src/test/java/expo/modules/accessibilityservice/UrlBarDetectionTest.kt
@@ -20,6 +20,10 @@ class UrlBarDetectionTest {
     private val chromeUrlBar = "com.android.chrome:id/url_bar"
     private val samsung = "com.sec.android.app.sbrowser"
     private val samsungUrlBar = "com.sec.android.app.sbrowser:id/location_bar_edit_text"
+    private val opera = "com.opera.browser"
+    private val operaUrlBar = "com.opera.browser:id/url_field"
+    private val firefox = "org.mozilla.firefox"
+    private val firefoxUrlBar = "org.mozilla.firefox:id/mozac_browser_toolbar_url_view"
 
     private lateinit var listener: AccessibilityService.EventListener
 
@@ -35,12 +39,35 @@ class UrlBarDetectionTest {
     }
 
     @Test
-    fun `isSupportedBrowser recognizes Chrome and Samsung Internet only`() {
-        assertTrue(AccessibilityService.isSupportedBrowser(chrome))
-        assertTrue(AccessibilityService.isSupportedBrowser(samsung))
-        assertFalse(AccessibilityService.isSupportedBrowser("org.mozilla.firefox"))
-        assertFalse(AccessibilityService.isSupportedBrowser("com.brave.browser"))
+    fun `isSupportedBrowser recognizes the popular Android browsers`() {
+        // Chromium family, Opera family, Firefox/Gecko, Samsung, DuckDuckGo
+        for (pkg in listOf(
+            chrome,
+            samsung,
+            opera,
+            firefox,
+            "com.brave.browser",
+            "com.microsoft.emmx",
+            "com.vivaldi.browser",
+            "com.opera.gx",
+            "org.mozilla.focus",
+            "com.duckduckgo.mobile.android",
+        )) {
+            assertTrue("expected $pkg to be supported", AccessibilityService.isSupportedBrowser(pkg))
+        }
+    }
+
+    @Test
+    fun `isSupportedBrowser rejects non-browsers and null`() {
+        assertFalse(AccessibilityService.isSupportedBrowser("com.whatsapp"))
+        assertFalse(AccessibilityService.isSupportedBrowser("com.google.android.youtube"))
         assertFalse(AccessibilityService.isSupportedBrowser(null))
+    }
+
+    @Test
+    fun `resolveUrlBarText resolves Opera and Firefox url bars`() {
+        assertEquals("facebook.com", AccessibilityService.resolveUrlBarText(opera, operaUrlBar, "facebook.com"))
+        assertEquals("reddit.com", AccessibilityService.resolveUrlBarText(firefox, firefoxUrlBar, "reddit.com"))
     }
 
     @Test
@@ -58,8 +85,8 @@ class UrlBarDetectionTest {
     @Test
     fun `resolveUrlBarText ignores non-browser packages`() {
         val result = AccessibilityService.resolveUrlBarText(
-            "org.mozilla.firefox",
-            "org.mozilla.firefox:id/url_bar_title",
+            "com.whatsapp",
+            "com.whatsapp:id/search_src_text",
             "facebook.com"
         )
         assertNull(result)

--- a/android/src/test/java/expo/modules/accessibilityservice/UrlBarDetectionTest.kt
+++ b/android/src/test/java/expo/modules/accessibilityservice/UrlBarDetectionTest.kt
@@ -1,0 +1,104 @@
+package expo.modules.accessibilityservice
+
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+
+/**
+ * Unit tests for the browser URL-bar detection added for website blocking (#19).
+ * Exercises the pure resolver (browser filtering + null-safety) and the
+ * listener notification path, without needing a real AccessibilityNodeInfo.
+ */
+class UrlBarDetectionTest {
+
+    private val chrome = "com.android.chrome"
+    private val chromeUrlBar = "com.android.chrome:id/url_bar"
+    private val samsung = "com.sec.android.app.sbrowser"
+    private val samsungUrlBar = "com.sec.android.app.sbrowser:id/location_bar_edit_text"
+
+    private lateinit var listener: AccessibilityService.EventListener
+
+    @Before
+    fun setUp() {
+        AccessibilityService.resetForTesting()
+        listener = mock()
+    }
+
+    @After
+    fun tearDown() {
+        AccessibilityService.resetForTesting()
+    }
+
+    @Test
+    fun `isSupportedBrowser recognizes Chrome and Samsung Internet only`() {
+        assertTrue(AccessibilityService.isSupportedBrowser(chrome))
+        assertTrue(AccessibilityService.isSupportedBrowser(samsung))
+        assertFalse(AccessibilityService.isSupportedBrowser("org.mozilla.firefox"))
+        assertFalse(AccessibilityService.isSupportedBrowser("com.brave.browser"))
+        assertFalse(AccessibilityService.isSupportedBrowser(null))
+    }
+
+    @Test
+    fun `resolveUrlBarText returns trimmed text for Chrome url bar`() {
+        val result = AccessibilityService.resolveUrlBarText(chrome, chromeUrlBar, "  facebook.com  ")
+        assertEquals("facebook.com", result)
+    }
+
+    @Test
+    fun `resolveUrlBarText returns text for Samsung Internet url bar`() {
+        val result = AccessibilityService.resolveUrlBarText(samsung, samsungUrlBar, "instagram.com")
+        assertEquals("instagram.com", result)
+    }
+
+    @Test
+    fun `resolveUrlBarText ignores non-browser packages`() {
+        val result = AccessibilityService.resolveUrlBarText(
+            "org.mozilla.firefox",
+            "org.mozilla.firefox:id/url_bar_title",
+            "facebook.com"
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `resolveUrlBarText ignores fields that are not the url bar`() {
+        // e.g. a content text view inside the page, not the omnibox
+        val result = AccessibilityService.resolveUrlBarText(chrome, "com.android.chrome:id/title_bar", "facebook.com")
+        assertNull(result)
+    }
+
+    @Test
+    fun `resolveUrlBarText is null-safe on empty text (new tab)`() {
+        assertNull(AccessibilityService.resolveUrlBarText(chrome, chromeUrlBar, ""))
+        assertNull(AccessibilityService.resolveUrlBarText(chrome, chromeUrlBar, "   "))
+        assertNull(AccessibilityService.resolveUrlBarText(chrome, chromeUrlBar, null))
+    }
+
+    @Test
+    fun `resolveUrlBarText is null-safe on null view id`() {
+        assertNull(AccessibilityService.resolveUrlBarText(chrome, null, "facebook.com"))
+    }
+
+    @Test
+    fun `notifyUrlBarListeners forwards to registered listeners`() {
+        AccessibilityService.addEventListener(listener)
+
+        AccessibilityService.notifyUrlBarListeners(chrome, "facebook.com", 123L)
+
+        verify(listener).onUrlBarChanged(eq(chrome), eq("facebook.com"), eq(123L))
+    }
+
+    @Test
+    fun `notifyUrlBarListeners does not invoke onAppChanged`() {
+        AccessibilityService.addEventListener(listener)
+
+        AccessibilityService.notifyUrlBarListeners(chrome, "facebook.com", 123L)
+
+        verify(listener, never()).onAppChanged(eq(chrome), org.mockito.kotlin.any(), org.mockito.kotlin.any())
+    }
+}


### PR DESCRIPTION
## Summary

Surfaces browser **URL-bar changes** as a typed detection event so the blocking overlay can implement website blocking. In-tab navigation does not fire a window-state change — it arrives as a text/content change, which the service previously ignored.

Foundation for [tied-siren-blocking-overlay#48](https://github.com/amehmeto/tied-siren-blocking-overlay/pull/48) and [TiedSiren#740](https://github.com/amehmeto/TiedSiren/pull/740).

## Changes

- `onAccessibilityEvent` now also handles `TYPE_VIEW_TEXT_CHANGED` / `TYPE_WINDOW_CONTENT_CHANGED`, **filtered to browser packages** (`com.android.chrome`, `com.sec.android.app.sbrowser`) to keep the hot path off every other app's content events.
- New `EventListener.onUrlBarChanged(packageName, rawText, timestamp)` (default no-op so existing listeners are unaffected). Normalization / eTLD+1 are the consumer's job — this layer only surfaces the raw URL-bar signal.
- Detection core is a pure, string-only `resolveUrlBarText(...)` so it is unit-testable without a real `AccessibilityNodeInfo`; null-safe on empty / new-tab / hint text. Prefers `event.text` over a fresh node query.
- No accessibility-config / manifest change required (already `typeAllMask` + `canRetrieveWindowContent`).

## Verification

- Jest: **72 passed**.
- Kotlin (`testDebugUnitTest`): **41 tests, 0 failures**, incl. new `UrlBarDetectionTest` (browser-only filtering, null-safety). Existing suites unchanged.

## Note on the base

Branched on top of `main` (`0314f2a`, "bind-truth detection + emit hardening") so it retains `isServiceRunning` / `openAppDetailsSettings`, which TiedSiren depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
